### PR TITLE
Expand parameters from array for callbacks

### DIFF
--- a/lib/resistance.js
+++ b/lib/resistance.js
@@ -10,7 +10,8 @@ var runSeries = function(fns, callback) {
     fns[completed](function(results) {
       data[completed] = results;
       if (++completed == fns.length) {
-        if (callback) callback(data);
+        // this is preferred for .apply but for size, we can use data
+        if (callback) callback.apply(data, data);
       } else {
         iterate();
       }
@@ -29,7 +30,7 @@ var runParallel = function(fns, callback) {
       return function(results) {
         data[i] = results;
         if (++completed == fns.length) {
-          if (callback) callback(data);
+          if (callback) callback.apply(data, data);
           return;
         }
       };


### PR DESCRIPTION
It is frustrating when I have to either always localize varaibles from the 'data' parameter or wrap the return function in an expand function (basically does .apply for me).

These changes should make the code using resistance slightly lighter and less frustrating.
